### PR TITLE
Inherit params

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,5 +22,5 @@ Suggests: testthat,
     knitr,
     rmarkdown,
     kableExtra
-RoxygenNote: 6.0.1
+RoxygenNote: 6.1.0
 VignetteBuilder: knitr

--- a/R/rt_queue_properties.R
+++ b/R/rt_queue_properties.R
@@ -3,7 +3,7 @@
 #' Get the data for a single queue.
 #'
 #' @param queue_id (character) The queue identifier
-#' @param rt_base (character) The base URL that hosts RT for your organization. Set the base URL in your R session using \code{options(rt_base = "https://server.name/rt/")}
+#' @inheritParams rt_login
 #'
 #' @export
 #'

--- a/R/rt_ticket_attachment.R
+++ b/R/rt_ticket_attachment.R
@@ -4,7 +4,9 @@
 #'
 #' @param ticket_id (numeric) The ticket identifier
 #' @param attachment_id (numeric) The attachment identifier
-#' @param rt_base (character) The base URL that hosts RT for your organization. Set the base URL in your R session using \code{options(rt_base = "https://server.name/rt/")}
+#' @inheritParams rt_login
+#'
+#' @family attachments
 #'
 #' @export
 #'

--- a/R/rt_ticket_attachment.R
+++ b/R/rt_ticket_attachment.R
@@ -6,8 +6,6 @@
 #' @param attachment_id (numeric) The attachment identifier
 #' @inheritParams rt_login
 #'
-#' @family attachments
-#'
 #' @export
 #'
 #' @examples

--- a/R/rt_ticket_attachment_content.R
+++ b/R/rt_ticket_attachment_content.R
@@ -2,9 +2,9 @@
 #'
 #' Retrieves attachment content
 #'
-#' @param ticket_id (numeric) The ticket identifier
-#' @param attachment_id (numeric) The attachment identifier
-#' @param rt_base (character) The base URL that hosts RT for your organization. Set the base URL in your R session using \code{options(rt_base = "https://server.name/rt/")}
+#' @inheritParams rt_ticket_attachment
+#'
+#' @family attachments
 #'
 #' @export
 #'

--- a/R/rt_ticket_attachment_content.R
+++ b/R/rt_ticket_attachment_content.R
@@ -4,8 +4,6 @@
 #'
 #' @inheritParams rt_ticket_attachment
 #'
-#' @family attachments
-#'
 #' @export
 #'
 #' @examples

--- a/R/rt_ticket_attachments.R
+++ b/R/rt_ticket_attachments.R
@@ -2,8 +2,9 @@
 #'
 #' Retrieves attachment metadata for a ticket
 #'
-#' @param ticket_id (numeric) The ticket identifier
-#' @param rt_base (character) The base URL that hosts RT for your organization. Set the base URL in your R session using \code{options(rt_base = "https://server.name/rt/")}
+#' @inheritParams rt_ticket_attachment
+#'
+#' @family attachments
 #'
 #' @export
 #'

--- a/R/rt_ticket_attachments.R
+++ b/R/rt_ticket_attachments.R
@@ -4,8 +4,6 @@
 #'
 #' @inheritParams rt_ticket_attachment
 #'
-#' @family attachments
-#'
 #' @export
 #'
 #' @examples

--- a/R/rt_ticket_create.R
+++ b/R/rt_ticket_create.R
@@ -2,7 +2,7 @@
 #'
 #' Create a new ticket in RT.
 #'
-#' @param queue (character) Queue name
+#' @inheritParams rt_queue_properties
 #' @param requestor (character) Requestor email address
 #' @param subject (character) Ticket subject
 #' @param cc (character) Email address to cc
@@ -17,7 +17,7 @@
 #' @param due (character) Due date ?????
 #' @param text (character) Ticket content; if multi-line, prefix every line with a blank
 #' @param custom_field (vector) Takes a named vector of the custom field name and custom field value
-#' @param rt_base (character) The base URL that hosts RT for your organization. Set the base URL in your R session using \code{options(rt_base = "https://server.name/rt/")}
+#' @inheritParams rt_login
 #'
 #' @export
 #'
@@ -26,7 +26,7 @@
 #' rt_ticket_create(priority = 2, custom_field = c(Description = "A description"))
 #' }
 
-rt_ticket_create <- function(queue = NULL,
+rt_ticket_create <- function(queue_id = NULL,
                            requestor = NULL,
                            subject = NULL,
                            cc = NULL,
@@ -44,7 +44,7 @@ rt_ticket_create <- function(queue = NULL,
                            rt_base = getOption("rt_base")) {
 
   params <- compact(list(id = "ticket/new",
-                         Queue = queue,
+                         Queue = queue_id,
                          Requestor = requestor,
                          Subject = subject,
                          Cc = cc,

--- a/R/rt_ticket_edit.R
+++ b/R/rt_ticket_edit.R
@@ -3,22 +3,7 @@
 #' Update an existing ticket with new information.
 #'
 #' @param ticket_id (numeric|character) The ticket number
-#' @param queue (character) Queue name
-#' @param requestor (character) Requestor email address
-#' @param subject (character) Ticket subject
-#' @param cc (character) Email address to cc
-#' @param admin_cc (character) Admin email address to cc
-#' @param owner (character) Owner username or email
-#' @param status (character) Ticket status; typically "open", "new", "stalled", or "resolved"
-#' @param priority (numeric) Ticket priority
-#' @param initial_priority (numeric) Ticket initial priority
-#' @param final_priority (numeric) Ticket final priority
-#' @param time_estimated (character) Time estimated ?????
-#' @param starts (character) Starts ?????
-#' @param due (character) Due date ?????
-#' @param text (character) Ticket content; if multi-line, prefix every line with a blank
-#' @param custom_field (vector) Takes a named vector of the custom field name and custom field value
-#' @param rt_base (character) The base URL that hosts RT for your organization. Set the base URL in your R session using \code{options(rt_base = "https://server.name/rt/")}
+#' @inheritParams rt_ticket_create
 #'
 #' @export
 #'
@@ -28,7 +13,7 @@
 #' }
 
 rt_ticket_edit <- function(ticket_id,
-                           queue = NULL,
+                           queue_id = NULL,
                            requestor = NULL,
                            subject = NULL,
                            cc = NULL,
@@ -47,7 +32,7 @@ rt_ticket_edit <- function(ticket_id,
   stopifnot(is.character(ticket_id) | is.numeric(ticket_id))
 
   params <- compact(list(id = ticket_id,
-                         Queue = queue,
+                         Queue = queue_id,
                          Requestor = requestor,
                          Subject = subject,
                          Cc = cc,

--- a/R/rt_ticket_history.R
+++ b/R/rt_ticket_history.R
@@ -2,11 +2,10 @@
 #'
 #' Retrieves information about the ticket history
 #'
-#' @param ticket_id (numeric) The ticket identifier
+#' @inheritParams rt_ticket_attachment
 #' @param format (character) Either  \code{s} (ticket ID and subject)
 #' or \code{l} (full ticket metadata).
 #' Defaults to \code{l}.
-#' @param rt_base (character) The base URL that hosts RT for your organization. Set the base URL in your R session using \code{options(rt_base = "https://server.name/rt/")}
 #'
 #' @export
 #'

--- a/R/rt_ticket_history_comment.R
+++ b/R/rt_ticket_history_comment.R
@@ -2,9 +2,8 @@
 #'
 #' Add a comment to an existing ticket
 #'
-#' @param ticket_id (numeric) The ticket identifier
+#' @inheritParams rt_ticket_attachment
 #' @param comment_text (character) Text that to add as a comment
-#' @param rt_base (character) The base URL that hosts RT for your organization. Set the base URL in your R session using \code{options(rt_base = "https://server.name/rt/")}
 #'
 #' @export
 #'

--- a/R/rt_ticket_history_reply.R
+++ b/R/rt_ticket_history_reply.R
@@ -2,13 +2,12 @@
 #'
 #' Add a response to an existing ticket
 #'
-#' @param ticket_id (numeric) The ticket identifier
+#' @inheritParams rt_ticket_attachment
 #' @param text (character) Text that to add as a comment
 #' @param cc (character) Email for cc
 #' @param bcc (character) Email for bcc
 #' @param time_worked (character)
 #' @param attachment_path (character) Path to a file to upload
-#' @param rt_base (character) The base URL that hosts RT for your organization. Set the base URL in your R session using \code{options(rt_base = "https://server.name/rt/")}
 #'
 #' @export
 #'

--- a/R/rt_ticket_links.R
+++ b/R/rt_ticket_links.R
@@ -3,8 +3,7 @@
 #' Gets the ticket links for a single ticket. If applicable, the following fields will be returned: \code{HasMember},
 #' \code{ReferredToBy}, \code{DependedOnBy}, \code{MemberOf}, \code{RefersTo}, and \code{DependsOn}.
 #'
-#' @param ticket_id (numeric|character) The ticket number
-#' @param rt_base (character) The base URL that hosts RT for your organization. Set the base URL in your R session using \code{options(rt_base = "https://server.name/rt/")}
+#' @inheritParams rt_ticket_attachment
 #'
 #' @export
 #'

--- a/R/rt_ticket_links_edit.R
+++ b/R/rt_ticket_links_edit.R
@@ -2,13 +2,12 @@
 #'
 #' Update links of an existing RT ticket.
 #'
-#' @param ticket_id (numeric|character) The ticket identifier
+#' @inheritParams rt_ticket_attachment
 #' @param referred_to_by Tickets that are referred to
 #' @param depended_on_by Tickets that are depended on
 #' @param member_of Ticket groups?
 #' @param refers_to Tickets that are referred to
 #' @param depends_on Tickets that are depended on
-#' @param rt_base (character) The base URL that hosts RT for your organization. Set the base URL in your R session using \code{options(rt_base = "https://server.name/rt/")}
 #'
 #' @export
 #'

--- a/R/rt_ticket_properties.R
+++ b/R/rt_ticket_properties.R
@@ -2,8 +2,7 @@
 #'
 #' Retrieves ticket properties
 #'
-#' @param ticket_id (numeric) The ticket identifier
-#' @param rt_base (character) The base URL that hosts RT for your organization. Set the base URL in your R session using \code{options(rt_base = "https://server.name/rt/")}
+#' @inheritParams rt_ticket_attachment
 #'
 #' @export
 #'

--- a/R/rt_ticket_search.R
+++ b/R/rt_ticket_search.R
@@ -7,7 +7,7 @@
 #' @param format (character) Either \code{i} (ticket ID only),
 #' \code{s} (ticket ID and subject), or \code{l} (full ticket metadata).
 #' Defaults to \code{l}.
-#' @param rt_base (character) The base URL that hosts RT for your organization. Set the base URL in your R session using \code{options(rt_base = "https://server.name/rt/")}
+#' @inheritParams rt_ticket_attachment
 #'
 #' @export
 #'

--- a/R/rt_user_create.R
+++ b/R/rt_user_create.R
@@ -10,7 +10,7 @@
 #' @param organization (character) Optional. User organization
 #' @param privileged (numeric) Optional. User privilege status
 #' @param disabled (numeric) Optional. User disabled status
-#' @param rt_base (character) The base URL that hosts RT for your organization. Set the base URL in your R session using \code{options(rt_base = "https://server.name/rt/")}
+#' @inheritParams rt_ticket_attachment
 #'
 #' @export
 #'

--- a/R/rt_user_edit.R
+++ b/R/rt_user_edit.R
@@ -2,15 +2,7 @@
 #'
 #' Add a comment to an existing ticket
 #'
-#' @param user_id (numeric) The user identifier
-#' @param password (character) The password
-#' @param name (character) Optional. User name
-#' @param email_address (character) Optional. User email
-#' @param real_name (character) Optional. User real name
-#' @param organization (character) Optional. User organization
-#' @param privileged (numeric) Optional. User privilege status
-#' @param disabled (numeric) Optional. User disabled status
-#' @param rt_base (character) The base URL that hosts RT for your organization. Set the base URL in your R session using \code{options(rt_base = "https://server.name/rt/")}
+#' @inheritParams rt_user_create
 #'
 #' @export
 #'

--- a/R/rt_user_properties.R
+++ b/R/rt_user_properties.R
@@ -3,8 +3,7 @@
 #' Gets the ticket links for a single ticket. If applicable, the following fields will be returned: \code{HasMember},
 #' \code{ReferredToBy}, \code{DependedOnBy}, \code{MemberOf}, \code{RefersTo}, and \code{DependsOn}.
 #'
-#' @param user_id (numeric|character) The user id or login.
-#' @param rt_base (character) The base URL that hosts RT for your organization. Set the base URL in your R session using \code{options(rt_base = "https://server.name/rt/")}
+#' @inheritParams rt_user_create
 #'
 #' @export
 #'

--- a/man/rt_ticket_attachment.Rd
+++ b/man/rt_ticket_attachment.Rd
@@ -4,7 +4,8 @@
 \alias{rt_ticket_attachment}
 \title{Get ticket attachment}
 \usage{
-rt_ticket_attachment(ticket_id, attachment_id, rt_base = getOption("rt_base"))
+rt_ticket_attachment(ticket_id, attachment_id,
+  rt_base = getOption("rt_base"))
 }
 \arguments{
 \item{ticket_id}{(numeric) The ticket identifier}
@@ -21,3 +22,8 @@ Retrieves attachment metadata
 rt_ticket_attachment(2, 1)
 }
 }
+\seealso{
+Other attachments: \code{\link{rt_ticket_attachment_content}},
+  \code{\link{rt_ticket_attachments}}
+}
+\concept{attachments}

--- a/man/rt_ticket_attachment_content.Rd
+++ b/man/rt_ticket_attachment_content.Rd
@@ -22,3 +22,8 @@ Retrieves attachment content
 rt_ticket_attachment_content(2, 1)
 }
 }
+\seealso{
+Other attachments: \code{\link{rt_ticket_attachments}},
+  \code{\link{rt_ticket_attachment}}
+}
+\concept{attachments}

--- a/man/rt_ticket_attachments.Rd
+++ b/man/rt_ticket_attachments.Rd
@@ -19,3 +19,8 @@ Retrieves attachment metadata for a ticket
 rt_ticket_attachments(2)
 }
 }
+\seealso{
+Other attachments: \code{\link{rt_ticket_attachment_content}},
+  \code{\link{rt_ticket_attachment}}
+}
+\concept{attachments}

--- a/man/rt_ticket_create.Rd
+++ b/man/rt_ticket_create.Rd
@@ -4,14 +4,14 @@
 \alias{rt_ticket_create}
 \title{Create an RT ticket}
 \usage{
-rt_ticket_create(queue = NULL, requestor = NULL, subject = NULL,
+rt_ticket_create(queue_id = NULL, requestor = NULL, subject = NULL,
   cc = NULL, admin_cc = NULL, owner = NULL, status = NULL,
   priority = NULL, initial_priority = NULL, final_priority = NULL,
   time_estimated = NULL, starts = NULL, due = NULL, text = NULL,
   custom_field = NULL, rt_base = getOption("rt_base"))
 }
 \arguments{
-\item{queue}{(character) Queue name}
+\item{queue_id}{(character) The queue identifier}
 
 \item{requestor}{(character) Requestor email address}
 

--- a/man/rt_ticket_edit.Rd
+++ b/man/rt_ticket_edit.Rd
@@ -4,16 +4,17 @@
 \alias{rt_ticket_edit}
 \title{Edit an RT ticket}
 \usage{
-rt_ticket_edit(ticket_id, queue = NULL, requestor = NULL, subject = NULL,
-  cc = NULL, admin_cc = NULL, owner = NULL, status = NULL,
-  priority = NULL, initial_priority = NULL, final_priority = NULL,
-  time_estimated = NULL, starts = NULL, due = NULL, text = NULL,
-  custom_field = NULL, rt_base = getOption("rt_base"))
+rt_ticket_edit(ticket_id, queue_id = NULL, requestor = NULL,
+  subject = NULL, cc = NULL, admin_cc = NULL, owner = NULL,
+  status = NULL, priority = NULL, initial_priority = NULL,
+  final_priority = NULL, time_estimated = NULL, starts = NULL,
+  due = NULL, text = NULL, custom_field = NULL,
+  rt_base = getOption("rt_base"))
 }
 \arguments{
 \item{ticket_id}{(numeric|character) The ticket number}
 
-\item{queue}{(character) Queue name}
+\item{queue_id}{(character) The queue identifier}
 
 \item{requestor}{(character) Requestor email address}
 

--- a/man/rt_ticket_history.Rd
+++ b/man/rt_ticket_history.Rd
@@ -4,7 +4,8 @@
 \alias{rt_ticket_history}
 \title{Get ticket history}
 \usage{
-rt_ticket_history(ticket_id, format = "l", rt_base = getOption("rt_base"))
+rt_ticket_history(ticket_id, format = "l",
+  rt_base = getOption("rt_base"))
 }
 \arguments{
 \item{ticket_id}{(numeric) The ticket identifier}

--- a/man/rt_ticket_links.Rd
+++ b/man/rt_ticket_links.Rd
@@ -7,7 +7,7 @@
 rt_ticket_links(ticket_id, rt_base = getOption("rt_base"))
 }
 \arguments{
-\item{ticket_id}{(numeric|character) The ticket number}
+\item{ticket_id}{(numeric) The ticket identifier}
 
 \item{rt_base}{(character) The base URL that hosts RT for your organization. Set the base URL in your R session using \code{options(rt_base = "https://server.name/rt/")}}
 }

--- a/man/rt_ticket_links_edit.Rd
+++ b/man/rt_ticket_links_edit.Rd
@@ -9,7 +9,7 @@ rt_ticket_links_edit(ticket_id, referred_to_by = NULL,
   depends_on = NULL, rt_base = getOption("rt_base"))
 }
 \arguments{
-\item{ticket_id}{(numeric|character) The ticket identifier}
+\item{ticket_id}{(numeric) The ticket identifier}
 
 \item{referred_to_by}{Tickets that are referred to}
 

--- a/man/rt_user_properties.Rd
+++ b/man/rt_user_properties.Rd
@@ -7,7 +7,7 @@
 rt_user_properties(user_id, rt_base = getOption("rt_base"))
 }
 \arguments{
-\item{user_id}{(numeric|character) The user id or login.}
+\item{user_id}{(numeric) The user identifier}
 
 \item{rt_base}{(character) The base URL that hosts RT for your organization. Set the base URL in your R session using \code{options(rt_base = "https://server.name/rt/")}}
 }


### PR DESCRIPTION
Only changed params...hopefully doesn't conflict with anything you've been doing, @amoeba!  

I started out using `@family` but I realized maybe we don't need it afterall since our naming convention autocompletes quite well?  Perhaps we could consider documenting several functions together with `@rdname` or `@describeIn` http://r-pkgs.had.co.nz/man.html#dry2

What do you think?